### PR TITLE
Aggregate similarity search scoring

### DIFF
--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -1,13 +1,13 @@
 # @memento-ai/agent
 
 ## Description
-The `@memento-ai/agent` package provides an abstract `Agent` class that represents a conversational agent or a specialized tool. Agents can be used in place of a `ConversationInterface` in a Conversation, and can be layered on top of or wrapped around another Agent.
+The `@memento-ai/agent` package provides an abstract `Agent` class that represents a conversational agent or a specialized tool. Agents can be used in place of a `ConversationInterface` in a conversation, and can be layered on top of or wrapped around another agent.
 
 ## Key Features
-- The `Agent` class provides a `forward` method that delegates to the `sendMessage` method of the underlying `ConversationInterface`.
-- The `Agent` class provides an abstract `generatePrompt` method that subclasses must implement to provide a prompt specific to the agent.
-- The `Agent` class provides a `send` method as a convenience for simple tools with a fixed prompt and a single message (no conversation history).
-- The `FunctionCallingAgent` subclass adds support for a `FunctionRegistry` to allow agents to invoke functions.
+- Provides an abstract `Agent` base class with `forward` and `send` methods for sending messages via a `ConversationInterface`.
+- Requires subclasses to implement a `generatePrompt` method to provide an agent-specific prompt.
+- Offers a `FunctionCallingAgent` subclass that adds support for a `FunctionRegistry` to allow agents to invoke functions.
+- Agents can optionally have a database connection via a `MementoDb` instance.
 
 ## Usage and Examples
 
@@ -16,7 +16,6 @@ To create a custom agent, extend the `Agent` class and implement the `generatePr
 
 ```typescript
 import { Agent, AgentArgs, SendArgs } from '@memento-ai/agent';
-import { AssistantMessage } from '@memento-ai/types';
 
 class MyAgent extends Agent {
   constructor(args: AgentArgs) {

--- a/packages/app/README.md
+++ b/packages/app/README.md
@@ -27,7 +27,7 @@ The options are:
 - `-C, --cwd <dir>` (optional): Use the specified directory as the current working directory (default: `.`)
 - `-D, --directory <dir>` (optional): The directory from which to recursively ingest files (default: `packages`)
 
-This will recursively ingest all files in the `packages` directory (or the directory specified with the `-D, --directory` option) into the specified database. The ingestion utility supports the file types used to implement Memento, which are listed in the `SUPPORTED_EXTENSIONS` constant.
+This will recursively ingest all files in the specified directory (default: `packages`) into the specified database. The ingestion utility supports the file types used to implement Memento, which are listed in the `SUPPORTED_EXTENSIONS` constant.
 
 The ingestion utility uses the specified provider and model to summarize the content of the files before storing them in the database.
 
@@ -43,6 +43,7 @@ bun run packages/app/src/cli.ts -p <provider> -m <model> -d <database>
 - `-m, --model <model>`: The name of the model to use
 - `-d, --database <dbname>`: The name of the database to use
 - `-x, --clean-slate` (optional): Drop the named database and start over
+- `-t, --tokens` (optional): Show token counts
 
 This will start the chatbot, which will persist the conversation history in the specified database. You can then interact with the chatbot by typing your messages and pressing Enter.
 
@@ -58,5 +59,8 @@ bun run packages/app/src/update-readmes.ts -p <provider> -m <model>
 
 - `-p, --provider <provider>`: The provider to use (e.g., `anthropic`, `ollama`, `openai`, ...)
 - `-m, --model <model>`: The model to use for generating the README content
+- `-P, --package <package>` (optional): Update only the specified package's README.md
 
 This utility will process each package in the `packages` directory, generating a README.md file based on the package's source code and the existing project README.md. It will also update the main project README.md file.
+
+If the `-P, --package` option is provided, only the specified package's README.md will be updated.

--- a/packages/embedding/README.md
+++ b/packages/embedding/README.md
@@ -12,18 +12,20 @@ The `@memento-ai/embedding` package provides functionality for generating text e
 
 ### Importing the Package
 ```typescript
-import { MyEmbeddingFunction } from '@memento-ai/embedding';
+import { MyEmbeddingFunction, embedding } from '@memento-ai/embedding';
 ```
 
 ### Creating an Instance
 ```typescript
-const embedding = new MyEmbeddingFunction();
+const embeddingInstance = new MyEmbeddingFunction();
 // or with a custom model
-const embedding = new MyEmbeddingFunction('custom-model');
+const embeddingInstance = new MyEmbeddingFunction('custom-model');
 ```
 
-### Generating Embeddings
+### Using the Default Instance
 ```typescript
+import { embedding } from '@memento-ai/embedding';
+
 // Generate embeddings for multiple texts
 const texts = ['hello world', 'goodbye world'];
 const embeddings = await embedding.generate(texts);
@@ -34,17 +36,29 @@ const singleEmbedding = await embedding.generateOne('hello world');
 console.log(singleEmbedding); // [...]
 ```
 
+### Generating Embeddings
+```typescript
+// Generate embeddings for multiple texts
+const texts = ['hello world', 'goodbye world'];
+const embeddings = await embeddingInstance.generate(texts);
+console.log(embeddings); // [[...], [...]]
+
+// Generate a single embedding
+const singleEmbedding = await embeddingInstance.generateOne('hello world');
+console.log(singleEmbedding); // [...]
+```
+
 ### Example Usage
 ```typescript
 import { MyEmbeddingFunction } from '@memento-ai/embedding';
 
-const embedding = new MyEmbeddingFunction();
+const embeddingInstance = new MyEmbeddingFunction();
 
 const text1 = 'The quick brown fox jumps over the lazy dog.';
 const text2 = 'A quick red fox jumps over the sleeping cat.';
 
-const embedding1 = await embedding.generateOne(text1);
-const embedding2 = await embedding.generateOne(text2);
+const embedding1 = await embeddingInstance.generateOne(text1);
+const embedding2 = await embeddingInstance.generateOne(text2);
 
 // Calculate the cosine similarity between the two embeddings
 const cosineSimilarity = calculateCosineSimilarity(embedding1, embedding2);

--- a/packages/function-calling/README.md
+++ b/packages/function-calling/README.md
@@ -6,7 +6,7 @@ The `@memento-ai/function-calling` package provides a framework for defining and
 - Invoke registered functions with provided input and context
 - Extract function call requests from content using a special code block syntax
 - Validate extracted function calls against registered function schemas
-- Execute multiple function calls in sequence
+- Execute multiple function calls in sequence, handling both synchronous and asynchronous functions
 - Handle function errors and results
 ## Usage and Examples
 ### Registering Functions
@@ -79,3 +79,22 @@ const functionCalls: FunctionCallRequest[] = [
 const context = { readonlyPool: db.readonlyPool };
 const results: FunctionCallResult[] = await invokeMultFunctions({ registry, calls: functionCalls, context });
 ```
+
+### Invoking Synchronous and Asynchronous Functions
+The `invokeSyncAndAsyncFunctions` function allows executing both synchronous and asynchronous function calls extracted from an assistant's message:
+
+```typescript
+import { invokeSyncAndAsyncFunctions, type InvokeFunctionsArgs, type InvokeFunctionsResults } from '@memento-ai/function-calling/src/invokeSyncAndAsyncFunctions';
+
+const invokeFunctionsArgs: InvokeFunctionsArgs = {
+  assistantMessage, 
+  context, 
+  registry, 
+  asyncResultsP: Promise.resolve([]), 
+  cycleCount: 1
+};
+
+const { functionResultContent, newAsyncResultsP }: InvokeFunctionsResults = await invokeSyncAndAsyncFunctions(invokeFunctionsArgs);
+```
+
+This will execute the synchronous functions immediately, while asynchronous functions will be invoked and their results will be available in the next cycle via the `newAsyncResultsP` promise.

--- a/packages/ingester/README.md
+++ b/packages/ingester/README.md
@@ -8,6 +8,10 @@ The `@memento-ai/ingester` package provides functionality for ingesting and summ
 - Configurable summarizer for generating document summaries
 - Automatically deletes ingested files from the database if they no longer exist on the file system
 - Retrieves a list of ingested files
+- Supports multiple summarizer types:
+  - Mock summarizer for testing
+  - Chat-based summarizer using a conversation interface
+  - Model-based summarizer using a specified provider and model
 
 ## Usage and Examples
 ### Ingesting a File
@@ -39,6 +43,15 @@ import { getIngestedFiles } from '@memento-ai/ingester';
 
 const db = await MementoDb.create('my-database');
 const ingestedFiles = await getIngestedFiles(db);
+```
+
+### Dropping Ingested Files
+```typescript
+import { MementoDb } from '@memento-ai/memento-db';
+import { dropIngestedFiles } from '@memento-ai/ingester';
+
+const db = await MementoDb.create('my-database');
+await dropIngestedFiles(db);
 ```
 
 ### Summarizing a Document

--- a/packages/memento-agent/README.md
+++ b/packages/memento-agent/README.md
@@ -13,6 +13,8 @@ It performs the important function of constructing the system prompt with dynami
 - Provides a dynamic prompt system that includes instructions for function calling and additional context from the database.
 - Handles asynchronous function calls, allowing for background updates to the database while continuing the conversation.
 - Supports configurable token limits for various types of content, such as conversation summaries, similarity search results, and synopses.
+- Generates a concise summary or "synopsis" of the latest conversational exchange between the user and assistant.
+- Allows the assistant to make "resolutions" to affect its future behavior based on user feedback.
 
 ## Usage and Examples
 The Memento Agent is designed to be used as part of the Memento system and is initialized with a conversation object, a database connection, and optional configuration parameters such as maximum token limits for various types of content.

--- a/packages/memento-agent/src/dynamicContent.ts
+++ b/packages/memento-agent/src/dynamicContent.ts
@@ -1,6 +1,6 @@
 // Path: packages/memento-agent/src/dynamicContent.ts
 
-import { selectSimilarMementos,  } from '@memento-ai/search';
+import { asSimilarityMap, combineMementoResults, selectSimilarMementos,  } from '@memento-ai/search';
 import { sql } from 'slonik';
 import type { MementoSearchArgs, MementoSearchResult, MementoSimilarityMap } from '@memento-ai/search';
 import type { MemKind, Message } from '@memento-ai/types';
@@ -109,11 +109,11 @@ export async function getRecentSynopses(db: MementoDb, maxSynopses: number = 30)
     return result.rows.map((row) => SynopsesIdPair.parse(row));
 }
 
-export async function gatherContent(db: MementoDb, args: MementoSearchArgs): Promise<DynamicContent> {
-    const maxMessagePairs = 5;
-    const similarMementos: MementoSimilarityMap = await selectSimilarMementos(db.pool, args);
+export async function gatherContent(db: MementoDb, results: MementoSearchResult[]): Promise<DynamicContent> {
+    const similarMementos: MementoSimilarityMap = await asSimilarityMap(results);
     const mementosByKind = indexMementosByKind(similarMementos);
 
+    const maxMessagePairs = 5;
     const messages: MessageIdPair[] = await getRecentConvesation(db, maxMessagePairs);
 
     // If the recent conversation message are contained in the additional context, remove them.

--- a/packages/memento-agent/src/retrieveContext.ts
+++ b/packages/memento-agent/src/retrieveContext.ts
@@ -7,6 +7,7 @@ import { registry } from "@memento-ai/function-calling";
 import type { DynamicContent } from "./dynamicContent";
 import type { MementoAgent } from "./mementoAgent";
 import type { MementoPromptTemplateArgs } from "./mementoPromptTemplate";
+import type { MementoSearchArgs, MementoSearchResult } from "@memento-ai/search";
 
 export function functionCallingInstructions() : string {
     return `
@@ -16,11 +17,10 @@ ${Object.values(registry)
 `.trim()
 }
 
-export async function retrieveContext(agent: MementoAgent): Promise<MementoPromptTemplateArgs> {
-    const { content } = agent.lastUserMessage;
+export async function retrieveContext(agent: MementoAgent, aggregateSearchResults: MementoSearchResult[]): Promise<MementoPromptTemplateArgs> {
     const functions = functionCallingInstructions();
 
-    const dynamicContent: DynamicContent = await gatherContent(agent.DB, { content, maxTokens: 16000, numKeywords: 5 });
+    const dynamicContent: DynamicContent = await gatherContent(agent.DB, aggregateSearchResults);
     const { additionalContext } = dynamicContent;
 
     const resolutions = await agent.DB.getResolutions();

--- a/packages/memento-db/README.md
+++ b/packages/memento-db/README.md
@@ -1,16 +1,17 @@
 # @memento-ai/memento-db
 ## Description
-The `@memento-ai/memento-db` package provides a TypeScript interface for interacting with a PostgreSQL database to store and retrieve "mementos" - pieces of information that are part of a conversational history. It includes functionality for adding different types of mementos (conversations, fragments, documents, and summaries), and searching for similar mementos.
+The `@memento-ai/memento-db` package provides a TypeScript interface for interacting with a PostgreSQL database to store and retrieve "mementos" - pieces of information that are part of a conversational history. It includes functionality for adding different types of mementos (conversations, fragments, documents, summaries, resolutions, and synopses), searching for similar mementos, and retrieving conversation history.
 
 ## Key Features
 - Add conversation mementos (user and assistant messages)
 - Add fragment mementos (excerpts from documents)
 - Add documents and their summaries
 - Add conversation exchange mementos (user-assistant message pairs)
+- Add resolution mementos 
+- Add synopsis mementos
 - Link conversation exchange mementos to synopsis mementos
 - Retrieve the conversation history
-- Search for mementos similar to a given user message using semantic similarity
-- Retrieve pinned conversation summary mementos
+- Retrieve resolution mementos
 - Retrieve synopses (short summaries) from the database
 - Get the last user and assistant messages in a conversation
 
@@ -49,6 +50,22 @@ await db.linkExchangeSynopsis({
   synopsis_id: 'synopsis-123'
 });
 
+// Add a resolution memento
+const resId = await db.addResolutionMem({
+  content: 'This is a resolution memento'
+});
+
+// Add a synopsis memento
+const synId = await db.addSynopsisMem({
+  content: 'This is a synopsis memento'
+});
+
+// Get the conversation history
+const conversation = await db.getConversation();
+
+// Get resolution mementos
+const resolutions = await db.getResolutions();
+
 // Get the last user and assistant messages
 const lastUserMessage = await db.get_last_user_message();
 const lastAssistantMessage = await db.get_last_assistant_message();
@@ -59,8 +76,11 @@ const lastAssistantMessage = await db.get_last_assistant_message();
 - `addFragmentMem`: Add a fragment memento to the database.
 - `addDocAndSummary`: Add a document and its summary to the database.
 - `addConvExchangeMementos`: Add a conversation exchange memento (user-assistant message pair).
+- `addResolutionMem`: Add a resolution memento to the database.
+- `addSynopsisMem`: Add a synopsis memento to the database.
 - `linkExchangeSynopsis`: Link a conversation exchange memento to a synopsis memento.
 - `getConversation`: Retrieve the conversation history as an array of messages.
+- `getResolutions`: Retrieve resolution mementos from the database.
 - `getSynopses`: Retrieve a list of synopses (short summaries) from the database.
 - `get_last_user_message`: Get the last user message in the conversation.
 - `get_last_assistant_message`: Get the last assistant message in the conversation.

--- a/packages/postgres-db/README.md
+++ b/packages/postgres-db/README.md
@@ -59,19 +59,15 @@ import { cleanUpLastUserMem } from '@memento-ai/postgres-db';
 // Clean up the last user message if the application crashed before responding
 await cleanUpLastUserMem(pool);
 ```
-### Retrieving the Last User Message
+### Retrieving the Last User and Assistant Messages
 ```typescript
-import { get_last_user_message } from '@memento-ai/postgres-db';
+import { get_last_user_message, get_last_assistant_message } from '@memento-ai/postgres-db';
 
 // Retrieve the last user message
 const lastUserMessage = await get_last_user_message(pool);
 console.log(lastUserMessage);
-```
-### Retrieving the Last Assistant Message
-```typescript
-import { get_last_assistant_message } from '@memento-ai/postgres-db';
 
-// Retrieve the last assistant message
+// Retrieve the last assistant message 
 const lastAssistantMessage = await get_last_assistant_message(conn);
 console.log(lastAssistantMessage);
 ```

--- a/packages/readme-agents/README.md
+++ b/packages/readme-agents/README.md
@@ -22,7 +22,8 @@ import { getProjectRoot } from '@memento-ai/utils';
 
 const projectRoot = getProjectRoot();
 const pkg = 'package-name'; // Replace with the desired package name
-const agent = new AddPackageReadmeAgent({ projectRoot, pkg, provider: 'anthropic', model: 'haiku' });
+const { provider, model } = defaultProviderAndModel;
+const agent = new AddPackageReadmeAgent({ projectRoot, pkg, provider, model });
 const readme = await agent.run();
 console.log(readme);
 ```
@@ -38,7 +39,8 @@ import { AddProjectReadmeAgent } from '@memento-ai/readme-agents';
 import { getProjectRoot } from '@memento-ai/utils';
 
 const projectRoot = getProjectRoot();
-const agent = new AddProjectReadmeAgent({ projectRoot, provider: 'anthropic', model: 'haiku' });
+const { provider, model } = defaultProviderAndModel;
+const agent = new AddProjectReadmeAgent({ projectRoot, provider, model });
 const readme = await agent.run();
 console.log(readme);
 ```

--- a/packages/readme-agents/src/package-readme-prompt-template.ts
+++ b/packages/readme-agents/src/package-readme-prompt-template.ts
@@ -11,7 +11,8 @@ export type PackageReadmePromptTemplateArgs = {
 };
 
 const packageReadmePromptTemplateText = stripCommonIndent(`
-    # Instructions
+    <system>
+    <instructions>
     Your task is to generate a README.md file for one package in the Memento monorepo.
     Memento is a Typescript application that uses PostgreSQL, so source files are primarily
     Typescript (*.ts), but may also include SQL files (*.sql) for database schema and queries.
@@ -22,17 +23,26 @@ const packageReadmePromptTemplateText = stripCommonIndent(`
     - The content of the source files in the package.
 
     Your response will replace the existing README.md file for the package.
-    You should examine the current README.md file to see if it is not up to date,
-    possibly due to recent changes to the source files in the package.
-    Update the document as warranted.
+
+    <note_well>
+    Examine the current README.md file carefully to determine if any parts are out of date.
+    Look for:
+    1. New key features implemented in the source files that are not documented in the README.md.
+    2. Features (e.g. functions) that are documented in the README but are no longer present in the source files.
+       Do not allow obsolete features to persist in the README.md. Examine import statements in the README file
+       for references to functions that are no longer present in the source files. Fix the README to
+       no longer refer to these functions in any way, rewriting any sample code in the README as necessary.
+    </note_well>
+
     If the current README.md is accurate and up to date you can simply respond with a copy
     of the current README.md content.
 
     The source files may include test files ending with .test.ts. Do not document these files,
-    but they will likely be useful for providing context and example usage.
+    but they will likely be useful for providing context and example usage, and you may refer
+    to them in your response.
 
     The format of the package README.md file should be:
-    \`\`\`markdown
+    <readme_format>
     # Package Name
     ## Description
     Briefly describe what the package does.
@@ -40,26 +50,27 @@ const packageReadmePromptTemplateText = stripCommonIndent(`
     List the main features or capabilities of the package.
     ## Usage and Examples
     Describe how to use the package, with examples if applicable.
-    \`\`\`
+    </readme_format>
+    </instructions>
 
-    ## Current Project README.md
-    \`\`\`markdown
-    {{project_readme}}
-    \`\`\`
+    <given_content>
+    <current_project_readme>
+    {{{project_readme}}}
+    </current_project_readme>
 
-    ## Package README.md
-    \`\`\`markdown
-    {{package_readme}}
-    \`\`\`
+    <current_package_readme>
+    {{{package_readme}}}
+    </current_package_readme>
 
-    ## Source Files
-    The following are the contents of the source files in the package:
+    <package_source_files>
     {{#each sources}}
-    ### File: {{this.path}}
-    \`\`\`typescript
-    {{this.content}}
-    \`\`\`
+    <file path="{{this.path}}">
+    {{{this.content}}}
+    </file>
     {{/each}}
+    </package_source_files>
+    </given_content>
+    </system>
 `);
 
 export const packageReadmePromptTemplate = Handlebars.compile<PackageReadmePromptTemplateArgs>(packageReadmePromptTemplateText);

--- a/packages/resolution-agent/README.md
+++ b/packages/resolution-agent/README.md
@@ -1,13 +1,18 @@
 # @memento-ai/resolution-agent
 
 ## Description
-The `@memento-ai/resolution-agent` package provides a Resolution Agent that monitors conversations between a user and an AI assistant. Its role is to identify and extract any resolutions made by the assistant to change its future behavior based on user feedback.
+The `@memento-ai/resolution-agent` package provides a Resolution Agent that monitors conversations between a user and an AI assistant. Its role is to identify and extract any explicit resolutions made by the assistant to change its future behavior based on user feedback.
 
 ## Key Features
 - Analyzes the most recent exchange between the user and assistant
-- Identifies explicit resolutions made by the assistant to change its future behavior
-- Extracts the resolution text and encloses it in `<resolution>` tags
+- Identifies explicit resolutions made by the assistant to change its future behavior, looking for:
+  1. User feedback about assistant behavior
+  2. Acknowledgement of the feedback by the assistant 
+  3. A statement from the assistant on how its behavior will be modified going forward
+- Extracts the resolution text, rephrasing for clarity and concision as needed
+- Encloses the extracted resolution in `<resolution>` tags
 - Handles cases where the assistant makes multiple resolutions in a single response
+- Avoids extracting duplicate resolutions by considering the current list of resolutions
 
 ## Usage and Examples
 
@@ -36,7 +41,7 @@ const resolutionText = await resolutionAgent.run();
 console.log(resolutionText);
 ```
 
-The `resolutionText` will contain the extracted resolution(s) enclosed in `<resolution>` tags, or an empty `<resolution></resolution>` tag if no resolutions were identified.
+The `resolutionText` will contain the extracted resolution(s) enclosed in `<resolution>` tags, or an empty `<resolution></resolution>` tag if no explicit resolutions were identified.
 
 Example output:
 

--- a/packages/search/README.md
+++ b/packages/search/README.md
@@ -1,4 +1,5 @@
 # @memento-ai/search
+
 ## Description
 The `@memento-ai/search` package provides functionality for searching and retrieving relevant mementos (pieces of information) from a Memento database. It allows users to find mementos that are similar to a given content based on keyword matching and semantic similarity using vector embeddings.
 
@@ -7,8 +8,9 @@ The `@memento-ai/search` package provides functionality for searching and retrie
 - Search for mementos similar to a given content based on keyword matching.
 - Search for mementos semantically similar to a given content using vector embeddings.
 - Combine keyword-based and semantic similarity-based search results to retrieve the most relevant mementos.
-- Normalize search scores using softmax or linear normalization to ensure scores are in the range [0, 1].
+- Normalize search scores using linear normalization to ensure scores are in the range [0, 1].
 - Limit search results based on a maximum token count to control the amount of information returned.
+- Avoid returning redundant mementos for documents, synopses, and conversations.
 
 ## Usage and Examples
 To use the `@memento-ai/search` package, you need to have a Memento database set up with a PostgreSQL connection pool.
@@ -25,7 +27,7 @@ const similarMementos = await selectSimilarMementos(db.pool, {
 });
 ```
 
-The `selectSimilarMementos` function combines the results from keyword-based and semantic similarity-based searches, normalizes the scores, and returns the most relevant mementos limited by the specified `maxTokens`.
+The `selectSimilarMementos` function combines the results from keyword-based and semantic similarity-based searches, normalizes the scores, and returns the most relevant mementos limited by the specified `maxTokens`. It also avoids returning redundant mementos for documents, synopses, and conversations.
 
 You can also perform keyword-based and semantic similarity-based searches separately:
 
@@ -46,14 +48,31 @@ const semanticSearchResults = await selectMemsBySemanticSimilarity(db.pool, {
 
 The `selectMemsByKeywordSearch` function performs a keyword-based search using the extracted keywords from the given content, while the `selectMemsBySemanticSimilarity` function performs a semantic similarity-based search using vector embeddings.
 
-The package also provides utility functions for normalizing search scores:
+The package also provides utility functions for normalizing search scores and combining search results:
 
 ```typescript
-import { softmaxNormalize, sumNormalize, linearNormalize } from '@memento-ai/search';
+import { linearNormalize, combineMementoResults } from '@memento-ai/search';
 
-const normalizedResults = softmaxNormalize(searchResults, (item) => item.score);
+const normalizedResults = linearNormalize(searchResults, (item) => item.score);
+const combinedResults = combineMementoResults({
+  lhs: keywordSearchResults,
+  rhs: semanticSearchResults,
+  maxTokens: 5000
+});
 ```
 
-These normalization functions ensure that the search scores are in the range [0, 1] and can be used to adjust the relative importance of different search results.
+These functions ensure that the search scores are in the range [0, 1] and can be used to adjust the relative importance of different search results. The `combineMementoResults` function combines the results of two memento searches into a single search result list, handling cases where mementos are present in one selection but not the other.
+
+### selectSimilarMemsUtil.ts
+
+The `selectSimilarMemsUtil.ts` file provides a command-line utility to experiment with semantic and keyword similarity searches. It can be used to observe examples of keyword and semantic search individually and when combined.
+
+To use the utility, run the following command:
+
+```bash
+bun run packages/search/src/selectSimilarMemsUtil.ts -d <dbname> -t 10000 -c 'Tell me about the Memento Project'
+```
+
+Replace `<dbname>` with the name of your Memento database and provide the desired search content after the `-c` flag.
 
 For more detailed usage and examples, please refer to the source code and tests in the `src` directory.

--- a/packages/search/README.md
+++ b/packages/search/README.md
@@ -48,10 +48,10 @@ const semanticSearchResults = await selectMemsBySemanticSimilarity(db.pool, {
 
 The `selectMemsByKeywordSearch` function performs a keyword-based search using the extracted keywords from the given content, while the `selectMemsBySemanticSimilarity` function performs a semantic similarity-based search using vector embeddings.
 
-The package also provides utility functions for normalizing search scores and combining search results:
+The package also provides utility functions for normalizing search scores, combining search results, and converting search results to a similarity map:
 
 ```typescript
-import { linearNormalize, combineMementoResults } from '@memento-ai/search';
+import { linearNormalize, combineMementoResults, asSimilarityMap } from '@memento-ai/search';
 
 const normalizedResults = linearNormalize(searchResults, (item) => item.score);
 const combinedResults = combineMementoResults({
@@ -59,13 +59,14 @@ const combinedResults = combineMementoResults({
   rhs: semanticSearchResults,
   maxTokens: 5000
 });
+const similarityMap = await asSimilarityMap(searchResults);
 ```
 
-These functions ensure that the search scores are in the range [0, 1] and can be used to adjust the relative importance of different search results. The `combineMementoResults` function combines the results of two memento searches into a single search result list, handling cases where mementos are present in one selection but not the other.
+These functions ensure that the search scores are in the range [0, 1] and can be used to adjust the relative importance of different search results. The `combineMementoResults` function combines the results of two memento searches into a single search result list, handling cases where mementos are present in one selection but not the other. The `asSimilarityMap` function converts the search results into a map where the keys are the memento IDs and the values are the corresponding search result objects.
 
 ### selectSimilarMemsUtil.ts
 
-The `selectSimilarMemsUtil.ts` file provides a command-line utility to experiment with semantic and keyword similarity searches. It can be used to observe examples of keyword and semantic search individually and when combined.
+The `selectSimilarMemsUtil.ts` source file provides a very useful command-line utility for experimenting with semantic and keyword similarity searches. It can be used to observe examples of keyword and semantic search individually and when combined.
 
 To use the utility, run the following command:
 
@@ -74,5 +75,7 @@ bun run packages/search/src/selectSimilarMemsUtil.ts -d <dbname> -t 10000 -c 'Te
 ```
 
 Replace `<dbname>` with the name of your Memento database and provide the desired search content after the `-c` flag.
+
+Output from selectSimilarMemsUtil is presented in easy to read tabular form using `console.table(...)`.
 
 For more detailed usage and examples, please refer to the source code and tests in the `src` directory.

--- a/packages/search/src/normalize.ts
+++ b/packages/search/src/normalize.ts
@@ -1,27 +1,7 @@
 // Path: packages/search/src/normalize.ts
 
-// This function takes an array of items and a key function that extracts a number from each item.
-// It normalizes the scores of the items using the softmax function.
-// The softmax function is used to convert a vector of arbitrary real values into a vector of probabilities.
-// This effectively normalizes the scores of the items so that they sum to 1.
-export function softmaxNormalize<T>(arr: T[], key: (item: T) => number): T[] {
-    const scores = arr.map(key);
-    const expScores = scores.map(Math.exp);
-    const sumExpScores = expScores.reduce((sum, score) => sum + score, 0);
-    const softmaxScores = expScores.map((score) => score / sumExpScores);
-    return arr.map((item, i) => ({...item, score: softmaxScores[i]}));
-}
-
-// As with softmax, produce an array of the same length as the input array, but with the scores normalized to sum to 1.
-// The difference is that this function uses the scores directly, rather than exponentiating them.
-// Requires that the scores are non-negative.
-export function sumNormalize<T>(arr: T[], key: (item: T) => number): T[] {
-    const scores = arr.map(key);
-    const sumScores = scores.reduce((sum, score) => sum + score, 0);
-    return arr.map((item, i) => ({...item, score: scores[i] / sumScores}));
-}
-
-// Normalize so that the range is 0..1
+// This function takes an array of items and a key function that extracts a number (a "score") from each item.
+// It return an array with the score normalized to use the full range of 0..1
 export function linearNormalize<T>(arr: T[], key: (item: T) => number): T[] {
     const scores: number[] = arr.map(key);
     const min: number = Math.min(...scores);

--- a/packages/search/src/selectSimilarMemsUtil.ts
+++ b/packages/search/src/selectSimilarMemsUtil.ts
@@ -1,12 +1,12 @@
 // Path: packages/search/src/tests/selectSimilarMemsUtil.ts
 
 import { Command } from 'commander';
-import { extractKeywordsFromContent } from '../extractKeywordsFromContent';
+import { extractKeywordsFromContent } from './extractKeywordsFromContent';
 import { MementoDb } from '@memento-ai/memento-db';
-import { selectMemsByKeywordSearch } from '../selectMemsByKeywordSearch';
-import { selectMemsBySemanticSimilarity } from '../selectMemsBySemanticSimilarity';
+import { selectMemsByKeywordSearch } from './selectMemsByKeywordSearch';
+import { selectMemsBySemanticSimilarity } from './selectMemsBySemanticSimilarity';
 import c from 'ansi-colors';
-import { selectSimilarMementos } from '../selectSimilarMementos';
+import { selectSimilarMementos } from './selectSimilarMementos';
 
 const program = new Command();
 

--- a/packages/synopsis-agent/README.md
+++ b/packages/synopsis-agent/README.md
@@ -36,4 +36,4 @@ The `SynopsisAgent` constructor takes an object with the following properties:
 - `db`: An instance of `MementoDb` for accessing the conversation history
 - `conversation`: An instance of `ConversationInterface` for generating the synopsis
 
-The `run` method of the `SynopsisAgent` retrieves the latest user and assistant messages, along with up to the last 1000 synopses, and generates a prompt using the `synopsis-prompt-template`. It then sends this prompt to the `conversation` instance to generate the synopsis, which is returned as a string.
+The `run` method of the `SynopsisAgent` retrieves the latest user and assistant messages, along with up to the last 1000 synopses, and generates a prompt using the `synopsis-prompt-template`. It then sends this prompt, along with additional instructions, to the `conversation` instance to generate the synopsis, which is returned as a string.

--- a/packages/types/README.md
+++ b/packages/types/README.md
@@ -5,7 +5,7 @@ The `@memento-ai/types` package provides the core data types, schemas, and utili
 
 ## Key Features
 - Defines the `Mem` object schema, which represents a single piece of content with its ID, content string, embedding vector, and token count.
-- Provides metadata schemas for different types of `Mem` objects, including conversations, documents, fragments, summaries, and synopses.
+- Provides metadata schemas for different types of `Mem` objects, including conversations, documents, fragments, summaries, synopses, resolutions, and conversation exchanges.
 - Includes enumerations for classifying `Mem` objects by their kind (e.g., conversation, document, fragment) and representing user and assistant roles.
 - Offers utility functions for creating `Mem` objects, parsing various data types, and constructing user and assistant messages.
 - Defines the `Memento` schema, which combines a metadata record with the linked `Mem` content record.
@@ -31,6 +31,8 @@ const conversationMeta: ConversationMetaData = {
     id: '123',
     memId: mem.id,
     role: USER,
+    docid: '456',
+    created_at: new Date(),
 };
 
 // Use the USER and ASSISTANT roles

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -1,7 +1,7 @@
 # @memento-ai/utils
 
 ## Description
-The `@memento-ai/utils` package provides a set of utility functions and tools for the Memento project. It includes functionality for finding the project root directory, generating README.md files for packages, adding path comments to TypeScript files, copying ingested mementos between databases, parsing input using Zod schemas with error handling, and removing common indentation from text blocks.
+The `@memento-ai/utils` package provides a set of utility functions and tools for the Memento project. It includes functionality for finding the project root directory, copying ingested mementos between databases, parsing input using Zod schemas with error handling, and removing common indentation from text blocks.
 
 ## Key Features
 - `getProjectRoot()` function to obtain the root directory of the Memento project


### PR DESCRIPTION
This change modifies the behavior for selecting relevant mementos (documents, summaries, historical conversation, etc) from the database for inclusion in the context window.

Prior to this change, only the most recent user message was use for creating the semantic and keyword query. 

With this change, the scoring algorithm used is now aggregated using simple exponential decay. We retain the aggregate scores used for the prior message, and compute a weighted sum of the scores created from the just the most recent message. This increases the likelihood that relevant mementos from the recent conversation will still be considered relevant when creating the context for the current request to the LLM. The weighting is currently 50/50 between the prior aggregate and the mementos selected from the current user message. This means the the just prior message accounts for 25% of the weight, the message prior to it accounts for 12.5% of the weight, and so on. I have not yet experimented with other weighting. 